### PR TITLE
Fix virtual endstop pin for homing moves

### DIFF
--- a/virtual_pins.py
+++ b/virtual_pins.py
@@ -412,6 +412,9 @@ class EndstopVirtualPin(VirtualPin):
 
     def home_start(self, print_time, sample_time, sample_count, rest_time,
                    triggered=True):
+        if self._home_timer is not None:
+            self._reactor.unregister_timer(self._home_timer)
+            self._home_timer = None
         self._triggered = triggered
         self._trigger_completion = self._reactor.completion()
         self._home_timer = self._reactor.register_timer(

--- a/virtual_pins.py
+++ b/virtual_pins.py
@@ -395,9 +395,14 @@ class AdcVirtualPin(VirtualPin):
         }
 
 class EndstopVirtualPin(VirtualPin):
+    RETRY_QUERY = 0.001  # pin poll interval during a homing move
+
     def __init__(self, mcu, pin_params, start_value):
         VirtualPin.__init__(self, mcu, pin_params, start_value)
         self._steppers = []
+        self._trigger_completion = None
+        self._triggered = True
+        self._home_timer = None
 
     def add_stepper(self, stepper):
         self._steppers.append(stepper)
@@ -407,12 +412,27 @@ class EndstopVirtualPin(VirtualPin):
 
     def home_start(self, print_time, sample_time, sample_count, rest_time,
                    triggered=True):
-        completion = self._reactor.completion()
-        completion.complete(True)
-        return completion
+        self._triggered = triggered
+        self._trigger_completion = self._reactor.completion()
+        self._home_timer = self._reactor.register_timer(
+            self._home_check, self._reactor.monotonic() + sample_time)
+        return self._trigger_completion
+
+    def _home_check(self, eventtime):
+        if self.query_endstop(eventtime) == (not not self._triggered):
+            self._trigger_completion.complete(True)
+            return self._reactor.NEVER
+        return eventtime + self.RETRY_QUERY
 
     def home_wait(self, home_end_time):
-        return 1
+        if self._home_timer is not None:
+            self._reactor.unregister_timer(self._home_timer)
+            self._home_timer = None
+        if self._trigger_completion is None:
+            return 0.
+        triggered = self._trigger_completion.test()
+        self._trigger_completion = None
+        return home_end_time if triggered else 0.
 
     def get_steppers(self):
         return list(self._steppers)


### PR DESCRIPTION
## Problem

`EndstopVirtualPin.home_start` returned an **already-completed** completion. During a homing / `STOP_ON_ENDSTOP` move, that completion is handed to `toolhead.drip_move` as the drip completion, and the drip loop breaks on the first iteration (`if drip_completion.test(): break`) before any steps are flushed — so the stepper never moves. The pin value was also never consulted during the move, and `home_wait` returned `1` unconditionally, so it always reported a trigger regardless of pin state.

This matches the reports in #3: the manual stepper does not rotate, and the endstop value has no effect.

## Fix

- `home_start` now returns a **pending** completion and registers a reactor timer that polls the pin value during the move, signalling the completion only once the pin reaches the requested triggered state. The drip move then stops at the trigger instead of immediately or never.
- `home_wait` cancels the poll timer and returns the trigger time on a hit, or `0.` so homing can correctly report *"No trigger after full movement"*.
- Poll interval is 1 ms, so short manual-stepper moves don't slip between polls and overshoot is minimal.

Because the drip loop yields to the reactor between segments, a `SET_VIRTUAL_PIN ... DELAY=` or `TEMPLATE=` change fires and is detected mid-move (g-code itself is blocked during the move).

Fixes #3